### PR TITLE
Better tests + Better types

### DIFF
--- a/.github/workflows/cov.yml
+++ b/.github/workflows/cov.yml
@@ -1,0 +1,32 @@
+name: Coverage
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', '.github/workflows/cov.yml' ]
+  push:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', '.github/workflows/cov.yml' ]
+    tags: '*'
+  workflow_dispatch:
+
+jobs:
+  determine-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Setup latest Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        pip install pip --upgrade
+        pip install .[dev]
+    - name: Test with pytest and create coverage report
+      run: pytest --cov=unfolding_linear --cov-report=xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', 'pyproject.toml', '.github/workflows/tests.yml' ]
+  push:
+    branches: [main]
+    paths: [ 'src/unfolding_linear/**', 'tests/**', 'pyproject.toml', '.github/workflows/tests.yml' ]
+    tags: '*'
+
+jobs:
+  run-tests:
+    name: Python ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ['3.8', '3.12']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Setup latest Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.version }}
+    - name: Install dependencies
+      run: |
+        pip install pip --upgrade
+        pip install .[dev]
+    - name: Test with pytest
+      run: pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['3.8', '3.12']
+        version: ['3.9', '3.12']
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Clone repository

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Python](https://img.shields.io/pypi/pyversions/tensorflow.svg?style=plastic)](https://pypi.org/project/unfolding-linear/) [![PyPI](https://badge.fury.io/py/unfolding-linear.svg)](https://pypi.org/project/unfolding-linear/)
+[![Tests](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml/badge.svg)](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml)
+[![docs](https://img.shields.io/badge/docs-click_here-blue.svg)](https://Salahberra2022.github.io/deep_unfolding/)
+[![PyPI](https://img.shields.io/pypi/v/unfolding-linear)](https://pypi.org/project/unfolding-linear/)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/unfolding-linear?color=blueviolet)
+[![GPLv3](https://img.shields.io/badge/license-GPLv3-yellowgreen.svg)](https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3)
 
 # unfolding-linear: Deep unfolding of iterative methods
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Tests](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml/badge.svg)](https://github.com/Salahberra2022/deep_unfolding/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/Salahberra2022/deep_unfolding/branch/main/graph/badge.svg?token=UPDATEME)](https://codecov.io/gh/Salahberra2022/deep_unfolding)
 [![docs](https://img.shields.io/badge/docs-click_here-blue.svg)](https://Salahberra2022.github.io/deep_unfolding/)
 [![PyPI](https://img.shields.io/pypi/v/unfolding-linear)](https://pypi.org/project/unfolding-linear/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/unfolding-linear?color=blueviolet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,15 @@ dependencies = [ "numpy >= 1.26", "torch >= 2.3" ]
 [project.optional-dependencies]
 dev = [
     "pdoc >= 14.5",
+    "coverage >= 7.2",
+    "mypy >= 1.5",
     "pytest >= 7.0",
-    "coverage",
+    "pytest-mypy >= 0.10.3",
     "pytest-cov >= 3.0.0" ]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = ""
+addopts = "--mypy"
 norecursedirs = [
     "hooks",
     "*.egg",
@@ -56,4 +58,11 @@ norecursedirs = [
     ".tox",
     ".git",
     "__pycache__" ]
-testpaths = ["src/unfolding_linear", "tests"]
+testpaths = [
+    "src/unfolding_linear",
+    "tests" ]
+
+[tool.mypy]
+python_version = "3.9"
+warn_unused_ignores = true
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ name = "unfolding_linear"
 description = "Deep unfolding of iterative methods to solve linear equations"
 version = "0.1.0"
 authors = [
-    { name = "Salah Berra", email = "salahberra39@gmail.com"},
-    { name = "Nennouche Mohamed", email = "moohaameed.nennouche@gmail.com"},
+    { name = "Salah Berra", email = "salahberra39@gmail.com" },
+    { name = "Nennouche Mohamed", email = "moohaameed.nennouche@gmail.com" },
     { name = "Nuno Fachada", email = "nuno.fachada@ulusofona.pt" }
 ]
 readme = "README.md"
@@ -28,7 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering"
 ]
-dependencies = [ "numpy >= 1.26", "torch>=2.3" ]
+dependencies = [ "numpy >= 1.26", "torch >= 2.3" ]
 
 [project.urls]
 "Homepage" = "https://github.com/Salahberra2022/deep_unfolding"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dev = [
     "pytest-mypy >= 0.10.3",
     "pytest-cov >= 3.0.0" ]
 
+[tool.setuptools.package-data]
+"*" = ["py.typed"]
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = "--mypy"

--- a/src/unfolding_linear/methods.py
+++ b/src/unfolding_linear/methods.py
@@ -4,6 +4,7 @@
 
 import torch
 import numpy as np
+from numpy.typing import NDArray
 from .utils import device, decompose_matrix
 
 
@@ -75,7 +76,7 @@ class base_model:
     """Inverse of the matrix $D + L$."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor):
         """Initialize the base_model with the given parameters and decompose matrix $A$.
 
         Args:
@@ -129,7 +130,7 @@ class GS(base_model):
     """The number of Gauss-Seidel iterations to perform."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor):
         """Initialize the Gauss-Seidel solver.
 
         Args:
@@ -201,7 +202,7 @@ class RI(base_model):
     """Inverse of the matrix $D + L$."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor):
         """Initialize the Richardson iteration solver.
 
         Args:
@@ -276,7 +277,7 @@ class Jacobi(base_model):
     """Relaxation parameter for Jacobi iterations."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 0.2):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 0.2):
         """Initialize the Jacobi iteration solver.
 
         Args:
@@ -354,7 +355,7 @@ class SOR(base_model):
     """Relaxation parameter for SOR iterations."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 1.8):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 1.8):
         """Initialize the SOR solver.
 
         Args:
@@ -443,7 +444,7 @@ class SOR_CHEBY(base_model):
     """Damping factor for SOR-Chebyshev iterations."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 1.8, omegaa: float = 0.8, gamma: float = 0.8):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 1.8, omegaa: float = 0.8, gamma: float = 0.8):
         """Initialize the SOR-Chebyshev solver.
 
         Args:
@@ -541,7 +542,7 @@ class AOR(base_model):
     """Relaxation parameter."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 0.3, r: float = 0.2):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 0.3, r: float = 0.2):
         """Initialize the AOR solver.
 
         Args:
@@ -629,7 +630,7 @@ class AOR_CHEBY(base_model):
     """Relaxation parameter."""
 
 
-    def __init__(self, n: int, A: np.ndarray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 0.1, r: float = 0.1):
+    def __init__(self, n: int, A: NDArray, H: torch.Tensor, bs: int, y: torch.Tensor, omega: float = 0.1, r: float = 0.1):
         """Initialize the AOR-Chebyshev solver.
 
         Args:

--- a/src/unfolding_linear/methods.py
+++ b/src/unfolding_linear/methods.py
@@ -4,8 +4,8 @@
 
 import torch
 import numpy as np
-from typing import List, Tuple
 from .utils import device, decompose_matrix
+
 
 def model_iterations(
     model,
@@ -13,7 +13,7 @@ def model_iterations(
     n: int,
     total_itr: int = 25,
     bs: int = 10000,
-) -> Tuple[List[torch.Tensor], List[float]]:
+) -> tuple[list[torch.Tensor], list[float]]:
     """Perform iterations using the provided model and calculate the error norm
       at each iteration.
 
@@ -141,7 +141,7 @@ class GS(base_model):
         """
         super(GS, self).__init__(n, A, H, bs, y)
 
-    def iterate(self, num_itr: int = 25) -> Tuple[torch.Tensor, list]:
+    def iterate(self, num_itr: int = 25) -> tuple[torch.Tensor, list]:
         """Performs the Gauss-Seidel iterations and returns the final solution
           and trajectory of solutions.
 
@@ -213,7 +213,7 @@ class RI(base_model):
         """
         super(RI, self).__init__(n, A, H, bs, y)
 
-    def iterate(self, num_itr: int = 25) -> Tuple[torch.Tensor, list]:
+    def iterate(self, num_itr: int = 25) -> tuple[torch.Tensor, list]:
         """Performs the Richardson iterations and returns the final solution and
           trajectory of solutions.
 
@@ -290,7 +290,7 @@ class Jacobi(base_model):
         super(Jacobi, self).__init__(n, A, H, bs, y)
         self.omega = torch.tensor(omega)
 
-    def iterate(self, num_itr: int = 25) -> Tuple[torch.Tensor, list]:
+    def iterate(self, num_itr: int = 25) -> tuple[torch.Tensor, list]:
         """Performs the Jacobi iterations and returns the final solution and
           trajectory of solutions.
 
@@ -368,7 +368,7 @@ class SOR(base_model):
         super(SOR, self).__init__(n, A, H, bs, y)
         self.omega = torch.tensor(omega)
 
-    def iterate(self, num_itr: int = 25) -> Tuple[torch.Tensor, list]:
+    def iterate(self, num_itr: int = 25) -> tuple[torch.Tensor, list]:
         """Performs the SOR iterations and returns the final solution and
           trajectory of solutions.
 
@@ -461,7 +461,7 @@ class SOR_CHEBY(base_model):
         self.omegaa = torch.tensor(omegaa)
         self.gamma = torch.tensor(gamma)
 
-    def iterate(self, num_itr: int = 25) -> Tuple[torch.Tensor, list]:
+    def iterate(self, num_itr: int = 25) -> tuple[torch.Tensor, list]:
         """Performs the SOR-Chebyshev iterations and returns the final solution
           and trajectory of solutions.
 
@@ -557,7 +557,7 @@ class AOR(base_model):
         self.omega = torch.tensor(omega)
         self.r = torch.tensor(r)
 
-    def iterate(self, num_itr: int = 25) -> Tuple[torch.Tensor, list]:
+    def iterate(self, num_itr: int = 25) -> tuple[torch.Tensor, list]:
         """Performs the AOR iterations and returns the final solution and
           trajectory of solutions.
 
@@ -645,7 +645,7 @@ class AOR_CHEBY(base_model):
         self.omega = torch.tensor(omega)
         self.r = torch.tensor(r)
 
-    def iterate(self, num_itr: int = 25) -> Tuple[torch.Tensor, list]:
+    def iterate(self, num_itr: int = 25) -> tuple[torch.Tensor, list]:
         """Performs the AOR-Chebyshev iterations and returns the final solution
           and trajectory of solutions.
 

--- a/src/unfolding_linear/train_methods.py
+++ b/src/unfolding_linear/train_methods.py
@@ -1,7 +1,7 @@
 from .utils import device, decompose_matrix
 import torch
 import torch.nn as nn
-from typing import Tuple, List
+
 
 def train_model(
     model: torch.nn.Module,
@@ -10,7 +10,7 @@ def train_model(
     solution: torch.Tensor,
     total_itr: int = 25,
     num_batch: int = 10000
-) -> Tuple[torch.nn.Module, List[float]]:
+) -> tuple[torch.nn.Module, list[float]]:
     """Train the given model using the specified optimizer and loss function.
 
     Args:
@@ -46,9 +46,9 @@ def evaluate_model(
     bs: int = 10000,
     total_itr: int = 25,
     device: torch.device = device
-) -> List[float]:
+) -> list[float]:
     """Evaluate the model by calculating the mean squared error (MSE) between
-    the solution and the model's predictions.
+      the solution and the model's predictions.
 
     Args:
       model: The model to be evaluated.
@@ -128,7 +128,7 @@ class SORNet(nn.Module):
         self.bs = bs
         self.y = y.to(device)
 
-    def forward(self, num_itr: int = 25) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+    def forward(self, num_itr: int = 25) -> tuple[torch.Tensor, list[torch.Tensor]]:
         """Perform forward pass of the SORNet model.
 
         Args:
@@ -224,7 +224,7 @@ class SOR_CHEBY_Net(nn.Module):
         self.bs = bs
         self.y = y.to(device)
 
-    def forward(self, num_itr: int = 25) -> Tuple[torch.Tensor, List[torch.Tensor]]:
+    def forward(self, num_itr: int = 25) -> tuple[torch.Tensor, list[torch.Tensor]]:
         """Perform forward pass of the SOR_CHEBY_Net model.
 
         Args:
@@ -295,7 +295,6 @@ class AORNet(nn.Module):
     y: torch.Tensor
     """Solution of the linear equation."""
 
-
     def __init__(self, A: torch.Tensor, H: torch.Tensor, bs: int, y: torch.Tensor, init_val_AORNet_r: float = 0.9, init_val_AORNet_omega: float = 1.5, device: torch.device = device):
         """
         Initialize the AORNet model.
@@ -324,7 +323,7 @@ class AORNet(nn.Module):
         self.bs = bs
         self.y = y.to(device)
 
-    def forward(self, num_itr: int = 25) -> Tuple[torch.Tensor, list[torch.Tensor]]:
+    def forward(self, num_itr: int = 25) -> tuple[torch.Tensor, list[torch.Tensor]]:
         """Perform forward pass of the AORNet model.
 
         Args:
@@ -407,7 +406,7 @@ class RINet(nn.Module):
         self.bs = bs
         self.y = y.to(device)
 
-    def forward(self, num_itr: int = 25) -> Tuple[torch.Tensor, list[torch.Tensor]]:
+    def forward(self, num_itr: int = 25) -> tuple[torch.Tensor, list[torch.Tensor]]:
         """Perform forward pass of the RINet model.
 
         Args:

--- a/src/unfolding_linear/utils.py
+++ b/src/unfolding_linear/utils.py
@@ -3,7 +3,9 @@
 # at https://www.gnu.org/licenses/)
 
 # This script contains the functions that will be used in the various modules of the dee_unfolding package.
+from __future__ import annotations
 import numpy as np
+from numpy.typing import NDArray
 import math
 import torch
 
@@ -13,7 +15,7 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu") # GPU, if 
 
 print(f"Code run on : {device}")
 
-def generate_A_H_sol(n: int = 300, m: int = 600, seed: int = 12, bs: int = 10, device: torch.device = device) -> tuple[np.ndarray, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+def generate_A_H_sol(n: int = 300, m: int = 600, seed: int = 12, bs: int = 10, device: torch.device = device) -> tuple[NDArray, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Generate matrices $A$, $H$, and $W$, as well as the solution and $y$.
 
     Args:
@@ -32,12 +34,12 @@ def generate_A_H_sol(n: int = 300, m: int = 600, seed: int = 12, bs: int = 10, d
         - Tensor $y$ resulting from `solution @ H` of shape (`bs`, `m`)
     """
     np.random.seed(seed=seed)
-    H = np.random.normal(0, 1.0 / math.sqrt(n), (n, m))
+    H: NDArray = np.random.normal(0, 1.0 / math.sqrt(n), (n, m))
     A = np.dot(H, H.T)
     eig = np.linalg.eig(A)[0]  # Eigenvalues
 
-    W = torch.Tensor(np.diag(eig)).to(device)  # Define the appropriate 'device'
-    H = torch.from_numpy(H).float().to(device)  # Define the appropriate 'device'
+    Wt = torch.Tensor(np.diag(eig)).to(device)  # Define the appropriate 'device'
+    Ht = torch.from_numpy(H).float().to(device)  # Define the appropriate 'device'
 
     print(f"""
     - Condition number of A: {np.max(eig) / np.min(eig)}
@@ -45,11 +47,11 @@ def generate_A_H_sol(n: int = 300, m: int = 600, seed: int = 12, bs: int = 10, d
     - Max eigenvalue of A: {np.max(eig)}""")
 
     solution = torch.normal(torch.zeros(bs, n), 1.0).to(device).detach()
-    y = solution @ H.detach()
+    y = solution @ Ht.detach()
 
-    return A, H, W, solution, y
+    return A, Ht, Wt, solution, y
 
-def decompose_matrix(A: np.ndarray) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+def decompose_matrix(A: NDArray | torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Decompose a given matrix into its diagonal, lower triangular, upper
     triangular components and their inverses.
 
@@ -73,11 +75,11 @@ def decompose_matrix(A: np.ndarray) -> tuple[torch.Tensor, torch.Tensor, torch.T
     invM = np.linalg.inv(D + L)  # Inverse of the matrix (D + L)
 
     # Convert to Torch tensors and move to device
-    A = torch.Tensor(A).to(device)
-    D = torch.Tensor(D).to(device)
-    L = torch.Tensor(L).to(device)
-    U = torch.Tensor(U).to(device)
-    Dinv = torch.Tensor(Dinv).to(device)
-    Minv = torch.Tensor(invM).to(device)
+    At = torch.Tensor(A).to(device)
+    Dt = torch.Tensor(D).to(device)
+    Lt = torch.Tensor(L).to(device)
+    Ut = torch.Tensor(U).to(device)
+    Dtinv = torch.Tensor(Dinv).to(device)
+    Mtinv = torch.Tensor(invM).to(device)
 
-    return A, D, L, U, Dinv, Minv
+    return At, Dt, Lt, Ut, Dtinv, Mtinv

--- a/src/unfolding_linear/utils.py
+++ b/src/unfolding_linear/utils.py
@@ -6,14 +6,14 @@
 import numpy as np
 import math
 import torch
-from typing import Tuple
+
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu") # GPU, if not CPU
 """The device where training will take place."""
 
 print(f"Code run on : {device}")
 
-def generate_A_H_sol(n: int = 300, m: int = 600, seed: int = 12, bs: int = 10, device: torch.device = device) -> Tuple[np.ndarray, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+def generate_A_H_sol(n: int = 300, m: int = 600, seed: int = 12, bs: int = 10, device: torch.device = device) -> tuple[np.ndarray, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Generate matrices $A$, $H$, and $W$, as well as the solution and $y$.
 
     Args:
@@ -49,7 +49,7 @@ def generate_A_H_sol(n: int = 300, m: int = 600, seed: int = 12, bs: int = 10, d
 
     return A, H, W, solution, y
 
-def decompose_matrix(A: np.ndarray) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+def decompose_matrix(A: np.ndarray) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Decompose a given matrix into its diagonal, lower triangular, upper
     triangular components and their inverses.
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -3,8 +3,10 @@
 import pytest
 import torch
 import numpy as np
-from unfolding_linear.methods import model_iterations, base_model, GS, RI, Jacobi, SOR, SOR_CHEBY, AOR, AOR_CHEBY
-from unfolding_linear.utils import device, decompose_matrix  # Assurez-vous que les utilitaires nécessaires sont importés correctement
+from unfolding_linear import (
+    model_iterations, base_model, GS, RI, Jacobi, SOR, SOR_CHEBY, AOR, AOR_CHEBY,
+    device, decompose_matrix
+)
 
 @pytest.fixture
 def generate_matrices():
@@ -25,11 +27,11 @@ def generate_solution():
 def test_model_iterations(generate_matrices, generate_solution):
     n, _, _, bs, _ = generate_matrices
     solution = generate_solution
-    
+
     class DummyModel:
         def iterate(self, i):
             return solution, []
-    
+
     model = DummyModel()
     s_hats, norm_list_model = model_iterations(model, solution, n, total_itr=5, bs=bs)
 
@@ -41,7 +43,7 @@ def test_model_iterations(generate_matrices, generate_solution):
 def test_base_model_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     model = base_model(n, A, H, bs, y)
-    
+
     assert model.n == n, "Attribute n should be initialized correctly"
     assert model.H.shape == H.shape, "Attribute H should be initialized correctly"
     assert model.bs == bs, "Attribute bs should be initialized correctly"
@@ -58,7 +60,7 @@ def test_base_model_initialization(generate_matrices):
 def test_GS_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     gs_model = GS(n, A, H, bs, y)
-    
+
     assert gs_model.n == n, "Attribute n should be initialized correctly in GS model"
     assert gs_model.H.shape == H.shape, "Attribute H should be initialized correctly in GS model"
     assert gs_model.bs == bs, "Attribute bs should be initialized correctly in GS model"
@@ -75,9 +77,9 @@ def test_GS_initialization(generate_matrices):
 def test_GS_iterate(generate_matrices):
     n, A, H, bs, y = generate_matrices
     gs_model = GS(n, A, H, bs, y)
-    
+
     s, traj = gs_model.iterate(num_itr=5)
-    
+
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert traj[0].shape == (bs, n), "Each element in the trajectory should have shape (bs, n)"
     assert s.shape == (bs, n), "Final solution tensor should have shape (bs, n)"
@@ -85,7 +87,7 @@ def test_GS_iterate(generate_matrices):
 def test_RI_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     ri_model = RI(n, A, H, bs, y)
-    
+
     assert ri_model.n == n, "Attribute n should be initialized correctly in RI model"
     assert ri_model.H.shape == H.shape, "Attribute H should be initialized correctly in RI model"
     assert ri_model.bs == bs, "Attribute bs should be initialized correctly in RI model"
@@ -102,7 +104,7 @@ def test_RI_initialization(generate_matrices):
 def test_RI_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     ri_model = RI(n, A, H, bs, y)
-    
+
     s, traj = ri_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -110,7 +112,7 @@ def test_RI_iteration(generate_matrices):
 def test_Jacobi_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     jacobi_model = Jacobi(n, A, H, bs, y, omega=0.2)
-    
+
     assert jacobi_model.n == n, "Attribute n should be initialized correctly in Jacobi model"
     assert jacobi_model.H.shape == H.shape, "Attribute H should be initialized correctly in Jacobi model"
     assert jacobi_model.bs == bs, "Attribute bs should be initialized correctly in Jacobi model"
@@ -128,7 +130,7 @@ def test_Jacobi_initialization(generate_matrices):
 def test_Jacobi_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     jacobi_model = Jacobi(n, A, H, bs, y, omega=0.2)
-    
+
     s, traj = jacobi_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -136,7 +138,7 @@ def test_Jacobi_iteration(generate_matrices):
 def test_SOR_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_model = SOR(n, A, H, bs, y, omega=1.8)
-    
+
     assert sor_model.n == n, "Attribute n should be initialized correctly in SOR model"
     assert sor_model.H.shape == H.shape, "Attribute H should be initialized correctly in SOR model"
     assert sor_model.bs == bs, "Attribute bs should be initialized correctly in SOR model"
@@ -154,7 +156,7 @@ def test_SOR_initialization(generate_matrices):
 def test_SOR_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_model = SOR(n, A, H, bs, y, omega=1.8)
-    
+
     s, traj = sor_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -162,7 +164,7 @@ def test_SOR_iteration(generate_matrices):
 def test_SOR_CHEBY_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_cheby_model = SOR_CHEBY(n, A, H, bs, y, omega=1.8, omegaa=0.8, gamma=0.8)
-    
+
     assert sor_cheby_model.n == n, "Attribute n should be initialized correctly in SOR_CHEBY model"
     assert sor_cheby_model.H.shape == H.shape, "Attribute H should be initialized correctly in SOR_CHEBY model"
     assert sor_cheby_model.bs == bs, "Attribute bs should be initialized correctly in SOR_CHEBY model"
@@ -182,7 +184,7 @@ def test_SOR_CHEBY_initialization(generate_matrices):
 def test_SOR_CHEBY_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     sor_cheby_model = SOR_CHEBY(n, A, H, bs, y, omega=1.8, omegaa=0.8, gamma=0.8)
-    
+
     s, traj = sor_cheby_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -190,7 +192,7 @@ def test_SOR_CHEBY_iteration(generate_matrices):
 def test_AOR_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_model = AOR(n, A, H, bs, y, omega=0.3, r=0.2)
-    
+
     assert aor_model.n == n, "Attribute n should be initialized correctly in AOR model"
     assert aor_model.H.shape == H.shape, "Attribute H should be initialized correctly in AOR model"
     assert aor_model.bs == bs, "Attribute bs should be initialized correctly in AOR model"
@@ -209,7 +211,7 @@ def test_AOR_initialization(generate_matrices):
 def test_AOR_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_model = AOR(n, A, H, bs, y, omega=0.3, r=0.2)
-    
+
     s, traj = aor_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"
@@ -217,7 +219,7 @@ def test_AOR_iteration(generate_matrices):
 def test_AOR_CHEBY_initialization(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_cheby_model = AOR_CHEBY(n, A, H, bs, y, omega=0.1, r=0.1)
-    
+
     assert aor_cheby_model.n == n, "Attribute n should be initialized correctly in AOR_CHEBY model"
     assert aor_cheby_model.H.shape == H.shape, "Attribute H should be initialized correctly in AOR_CHEBY model"
     assert aor_cheby_model.bs == bs, "Attribute bs should be initialized correctly in AOR_CHEBY model"
@@ -236,7 +238,7 @@ def test_AOR_CHEBY_initialization(generate_matrices):
 def test_AOR_CHEBY_iteration(generate_matrices):
     n, A, H, bs, y = generate_matrices
     aor_cheby_model = AOR_CHEBY(n, A, H, bs, y, omega=0.1, r=0.1)
-    
+
     s, traj = aor_cheby_model.iterate(num_itr=5)
     assert len(traj) == 6, "Trajectory should contain num_itr + 1 elements"
     assert s.shape == (bs, n), "Final solution tensor should have the correct shape"

--- a/tests/test_train_methods.py
+++ b/tests/test_train_methods.py
@@ -1,8 +1,10 @@
 import pytest
 import torch
 import torch.nn as nn
-from unfolding_linear.train_methods import train_model, evaluate_model, SORNet, SOR_CHEBY_Net, AORNet, RINet 
-from unfolding_linear.utils import device, generate_A_H_sol  
+from unfolding_linear import (
+    train_model, evaluate_model, SORNet, SOR_CHEBY_Net, AORNet, RINet,
+    device, generate_A_H_sol
+)
 
 # Fixture pour générer les matrices et tensors nécessaires
 @pytest.fixture
@@ -16,7 +18,7 @@ def generate_matrices():
 def test_SORNet_initialization(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = SORNet(A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -30,9 +32,9 @@ def test_SORNet_initialization(generate_matrices):
 def test_SORNet_forward(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = SORNet(A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=3)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == 4, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -42,7 +44,7 @@ def test_SOR_CHEBY_Net_initialization(generate_matrices):
     num_itr = 25
     A, H, y, n, m, bs, solution = generate_matrices
     model = SOR_CHEBY_Net(num_itr, A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -61,9 +63,9 @@ def test_SOR_CHEBY_Net_forward(generate_matrices):
     num_itr = 3
     A, H, y, n, m, bs, solution = generate_matrices
     model = SOR_CHEBY_Net(num_itr, A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=num_itr)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == num_itr + 1, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -73,7 +75,7 @@ def test_SOR_CHEBY_Net_forward(generate_matrices):
 def test_AORNet_initialization(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = AORNet(A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -88,9 +90,9 @@ def test_AORNet_initialization(generate_matrices):
 def test_AORNet_forward(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = AORNet(A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=3)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == 4, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -99,7 +101,7 @@ def test_AORNet_forward(generate_matrices):
 def test_RINet_initialization(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = RINet(A, H, bs, y, device=device)
-    
+
     assert model.A.shape == (n, n), "Attribute A should have the correct shape"
     assert model.H.shape == (n, m), "Attribute H should have the correct shape"
     assert model.D.shape == (n, n), "Attribute D should have the correct shape"
@@ -113,9 +115,9 @@ def test_RINet_initialization(generate_matrices):
 def test_RINet_forward(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = RINet(A, H, bs, y, device=device)
-    
+
     s, traj = model.forward(num_itr=3)
-    
+
     assert s.shape == (bs, n), "Output tensor should have the correct shape"
     assert len(traj) == 4, "Trajectory should contain num_itr + 1 elements"
     assert all(t.shape == (bs, n) for t in traj), "Each element in the trajectory should have the correct shape"
@@ -130,16 +132,16 @@ def test_train_model(generate_matrices):
     loss_func = nn.MSELoss()
 
     trained_model, loss_gen = train_model(model, optimizer, loss_func, solution, total_itr=3, num_batch=5)
-    
+
     assert isinstance(trained_model, SORNet), "Returned model should be of type SORNet"
     assert len(loss_gen) == 3, "Length of loss_gen should be equal to total_itr"
 
 def test_evaluate_model(generate_matrices):
     A, H, y, n, m, bs, solution = generate_matrices
     model = SORNet(A, H, bs, y, device=device)
-    
+
     norm_list = evaluate_model(model, solution, n, bs=bs, total_itr=3, device=device)
-    
+
     assert len(norm_list) == 4, "Length of norm_list should be equal to total_itr + 1"
     assert all(isinstance(err, float) for err in norm_list), "All elements in norm_list should be floats"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from unfolding_linear.utils import generate_A_H_sol, decompose_matrix
+from unfolding_linear import generate_A_H_sol, decompose_matrix
 import pytest
 import torch
 import numpy as np


### PR DESCRIPTION
This pull request makes the following changes:

- Tests run automatically (in GitHub) on each push in Windows, Linux and MacOS and Python 3.9 and Python 3.12
- Tests coverage is automatically measured and sent to CodeCov (see note below)
- Test type usage with mypy
- Fix some incorrect previous type usage
- Update `README.md` badges to show test results, test coverage, number of PyPI downloads, docs link, etc.

For CodeCov code coverage to work, the repository will need to be public. After that create a free account on [CodeCov](https://app.codecov.io/login) (login with GitHub credentials) and setup the `Salahberra2022/deep_unfolding` repo. After the next push or pull request merge to the repository, the coverage report is uploaded to CodeCov.

Then one can update the CodeCov badge in `README.md` as follows: in CodeCov, go to `Salahberra2022/deep_unfolding`, then Settings, then Badges & Graphs, then copy-paste the Markdown badge code and replace the current one in the `README.md`. I can also do this afterwards, no worries. You only need to create the CodeCov account and setup the `Salahberra2022/deep_unfolding` repo there.